### PR TITLE
ガンマ補正

### DIFF
--- a/image.go
+++ b/image.go
@@ -185,6 +185,12 @@ func (i *Image) Trim() ([]byte, error) {
 	return i.Process(options)
 }
 
+// Gamma returns the gamma filtered image buffer.
+func (i *Image) Gamma(exponent float64) ([]byte, error) {
+	options := Options{Gamma: exponent}
+	return i.Process(options)
+}
+
 // Process processes the image based on the given transformation options,
 // talking with libvips bindings accordingly and returning the resultant
 // image buffer.

--- a/options.go
+++ b/options.go
@@ -222,5 +222,6 @@ type Options struct {
 	GaussianBlur   GaussianBlur
 	Sharpen        Sharpen
 	Threshold      float64
+	Gamma          float64
 	OutputICC      string
 }

--- a/resizer.go
+++ b/resizer.go
@@ -125,6 +125,12 @@ func resizer(buf []byte, o Options) ([]byte, error) {
 		return nil, err
 	}
 
+	// Apply Gamma filter, if necessary
+	image, err = applyGamma(image, o)
+	if err != nil {
+		return nil, err
+	}
+
 	return saveImage(image, o)
 }
 
@@ -380,6 +386,17 @@ func imageFlatten(image *C.VipsImage, imageType ImageType, o Options) (*C.VipsIm
 		return image, nil
 	}
 	return vipsFlattenBackground(image, o.Background)
+}
+
+func applyGamma(image *C.VipsImage, o Options) (*C.VipsImage, error) {
+	var err error
+	if o.Gamma > 0 {
+		image, err = vipsGamma(image, o.Gamma)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return image, nil
 }
 
 func zoomImage(image *C.VipsImage, zoom int) (*C.VipsImage, error) {

--- a/vips.go
+++ b/vips.go
@@ -703,3 +703,14 @@ func vipsDrawWatermark(image *C.VipsImage, o WatermarkImage) (*C.VipsImage, erro
 
 	return out, nil
 }
+
+func vipsGamma(image *C.VipsImage, Gamma float64) (*C.VipsImage, error) {
+	var out *C.VipsImage
+	defer C.g_object_unref(C.gpointer(image))
+
+	err := C.vips_gamma_bridge(image, &out, C.double(Gamma))
+	if err != 0 {
+		return nil, catchVipsError()
+	}
+	return out, nil
+}

--- a/vips.h
+++ b/vips.h
@@ -561,3 +561,8 @@ int vips_find_trim_bridge(VipsImage *in, int *top, int *left, int *width, int *h
 	return 0;
 #endif
 }
+
+int vips_gamma_bridge(VipsImage *in, VipsImage **out, double exponent)
+{
+  return vips_gamma(in, out, "exponent", 1.0 / exponent, NULL);
+}


### PR DESCRIPTION
使い方の例
buf, err = bimg.NewImage(buf).Gamma(0.454545)